### PR TITLE
[closes #51] automatically configure publish path

### DIFF
--- a/examples/helix-basic-unicorn/build/config/build-and-sync.json
+++ b/examples/helix-basic-unicorn/build/config/build-and-sync.json
@@ -58,12 +58,20 @@
         }
     },
     "Tasks" : {
+        "WritePublishUserPath": {
+            "Description": "Configure Publish path for MSBuild",
+            "Type": "WritePublishUserPath",
+            "Params": {
+                "PublishPath": "[parameter('PublishPath')]",
+                "DestinationPath": "[concat(parameter('SourceFolder'), '\\Deployment\\Website\\Properties\\PublishProfiles\\Local.pubxml.user.props')]"
+            }
+        },
         "Build": {
-            "Description": "Build the Visual Studio solution",
+            "Description": "Build and Publish the Visual Studio solution",
             "Type": "MsBuild",
             "Params": {
                 "Path": "[parameter('BuildProject')]",
-                "MsBuildParameters": "[concat('/restore /m /p:DeployOnBuild=true /p:PublishProfile=', parameter('PublishProfile'), ' /p:publishUrl=', parameter('PublishPath'), ' /verbosity:', parameter('BuildVerbosity'))]",
+                "MsBuildParameters": "[concat('/restore /m /p:DeployOnBuild=true /p:PublishProfile=', parameter('PublishProfile'), ' /verbosity:', parameter('BuildVerbosity'))]",
                 "ShowBuildOutputInCurrentWindow": true
             }
         },

--- a/examples/helix-basic-unicorn/src/Deployment/Website/Properties/PublishProfiles/.gitignore
+++ b/examples/helix-basic-unicorn/src/Deployment/Website/Properties/PublishProfiles/.gitignore
@@ -1,0 +1,1 @@
+Local.pubxml.user.props

--- a/examples/helix-basic-unicorn/src/Deployment/Website/Properties/PublishProfiles/Local.pubxml
+++ b/examples/helix-basic-unicorn/src/Deployment/Website/Properties/PublishProfiles/Local.pubxml
@@ -12,7 +12,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
     <ExcludeApp_Data>False</ExcludeApp_Data>
-    <publishUrl>C:\inetpub\wwwroot\helix-basic-unicorn.dev.local</publishUrl>
     <DeleteExistingFiles>False</DeleteExistingFiles>
   </PropertyGroup>
+  <Import Project="Local.pubxml.user.props" Condition="Exists('Local.pubxml.user.props')" />
 </Project>

--- a/install-modules/helix.examples.psm1
+++ b/install-modules/helix.examples.psm1
@@ -321,6 +321,24 @@ Function Write-SourceFolderConfigPatch {
     Write-Information "Wrote to $DestinationPath"
 }
 
+Function Write-PublishUserPath {
+    Param(
+        [string]$PublishPath,
+        [string]$DestinationPath
+    )
+    $xml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <publishUrl>$PublishPath</publishUrl>
+    </PropertyGroup>
+</Project>
+"@
+    Write-Information "MSBuild publish configuration: $xml"
+    $xml > $DestinationPath
+    Write-Information "Wrote to $DestinationPath"
+}
+
 Function Invoke-SitecoreWarmup {
     Param(
         [string]$SitecoreUrl,


### PR DESCRIPTION
* put publishUrl in custom props file, ignored by git
* create/configure during initial install
* in case instance is configured to install elsewhere