### PR TITLE
Update Dockerfile

### DIFF
--- a/examples/helix-basic-aspnetcore/docker/build/dotnetsdk/Dockerfile
+++ b/examples/helix-basic-aspnetcore/docker/build/dotnetsdk/Dockerfile
@@ -11,6 +11,8 @@ ARG NETCORE_BUILD_IMAGE
 FROM ${NETCORE_BUILD_IMAGE} as netcore-sdk
 FROM ${BUILD_IMAGE}
 
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # Ensure updated nuget. Depending on your Windows version, dotnet/framework/sdk:4.8 tag may provide an outdated client.
 # See https://github.com/microsoft/dotnet-framework-docker/blob/1c3dd6638c6b827b81ffb13386b924f6dcdee533/4.8/sdk/windowsservercore-ltsc2019/Dockerfile#L7
 ENV NUGET_VERSION 5.8.0


### PR DESCRIPTION
I've to make this change in order to make it working. Otherwise I was getting the following exception (as it was trying to use CMD as shell):

'Invoke-WebRequest' is not recognized as an internal or external command,
operable program or batch file.
ERROR: Service 'dotnetsdk' failed to build : The command 'cmd /S /C Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/v$env:NUGET_VERSION/nuget.exe" -UseBasicParsing -OutFile "$env:ProgramFiles\NuGet\nuget.exe"' returned a non-zero code: 1

Same issue will happen with the RUN $path command.