### PR TITLE
Running Multiple Sitecore Docker-Compose Environments with Traefik

### DIFF
--- a/examples/helix-basic-aspnetcore/docker-compose.override.yml
+++ b/examples/helix-basic-aspnetcore/docker-compose.override.yml
@@ -55,6 +55,7 @@ services:
       - ./docker/traefik:C:/etc/traefik
     depends_on:
       - rendering
+    # scale: 0
   
   redis:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-redis:${VERSION:-latest}

--- a/examples/helix-basic-aspnetcore/docker-compose.override.yml
+++ b/examples/helix-basic-aspnetcore/docker-compose.override.yml
@@ -46,9 +46,9 @@ services:
       - cd
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.rendering-secure.entrypoints=websecure"
-      - "traefik.http.routers.rendering-secure.rule=Host(`${RENDERING_HOST}`)"
-      - "traefik.http.routers.rendering-secure.tls=true"
+      - "traefik.http.routers.rendering-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.rendering-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${RENDERING_HOST}`)"
+      - "traefik.http.routers.rendering-${COMPOSE_PROJECT_NAME}-secure.tls=true"
 
   traefik:
     volumes:

--- a/examples/helix-basic-aspnetcore/docker-compose.yml
+++ b/examples/helix-basic-aspnetcore/docker-compose.yml
@@ -37,8 +37,6 @@ services:
       SA_PASSWORD: ${SQL_SA_PASSWORD}
       SITECORE_ADMIN_PASSWORD: ${SITECORE_ADMIN_PASSWORD}
       ACCEPT_EULA: "Y"
-    ports:
-      - "14330:1433"
     volumes:
       - type: bind
         source: .\mssql-data
@@ -46,8 +44,6 @@ services:
   solr:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}nonproduction/solr:8.4.0-${SITECORE_VERSION}
-    ports:
-      - "8984:8983"
     volumes:
       - type: bind
         source: .\solr-data

--- a/examples/helix-basic-aspnetcore/docker-compose.yml
+++ b/examples/helix-basic-aspnetcore/docker-compose.yml
@@ -79,9 +79,9 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.id-secure.entrypoints=websecure"
-      - "traefik.http.routers.id-secure.rule=Host(`${ID_HOST}`)"
-      - "traefik.http.routers.id-secure.tls=true"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${ID_HOST}`)"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cd:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cd:${SITECORE_VERSION}
@@ -107,9 +107,9 @@ services:
       timeout: 300s
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cd-secure.entrypoints=websecure"
-      - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
-      - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cm:${SITECORE_VERSION}
@@ -146,7 +146,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.middlewares.force-STS-Header.headers.forceSTSHeader=true"
       - "traefik.http.middlewares.force-STS-Header.headers.stsSeconds=31536000"
-      - "traefik.http.routers.cm-secure.entrypoints=websecure"
-      - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
-      - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CM_HOST}`)"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.tls=true"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.middlewares=force-STS-Header"

--- a/examples/helix-basic-aspnetcore/up.ps1
+++ b/examples/helix-basic-aspnetcore/up.ps1
@@ -24,7 +24,12 @@ $startTime = Get-Date
 do {
     Start-Sleep -Milliseconds 100
     try {
-        $status = Invoke-RestMethod "http://localhost:8079/api/http/routers/cm-secure@docker"
+
+        #WORKAROUND: https://github.com/Sitecore/docker-tools/issues/38
+        $envFileAbsolutePath = $(Get-Item -Path ".env").FullName
+
+        $compose_project_name = Get-EnvFileVariable -Variable "COMPOSE_PROJECT_NAME" -Path $envFileAbsolutePath
+        $status = Invoke-RestMethod "http://localhost:8079/api/http/routers/cm-$compose_project_name-secure@docker"
     } catch {
         if ($_.Exception.Response.StatusCode.value__ -ne "404") {
             throw

--- a/examples/helix-basic-nextjs/docker-compose.override.yml
+++ b/examples/helix-basic-nextjs/docker-compose.override.yml
@@ -51,9 +51,9 @@ services:
       - nodejs
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.rendering-secure.entrypoints=websecure"
-      - "traefik.http.routers.rendering-secure.rule=Host(`${RENDERING_HOST}`)"
-      - "traefik.http.routers.rendering-secure.tls=true"
+      - "traefik.http.routers.rendering-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.rendering-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${RENDERING_HOST}`)"
+      - "traefik.http.routers.rendering-${COMPOSE_PROJECT_NAME}-secure.tls=true"
 
   # Mount the Traefik configuration and certs.
   traefik:

--- a/examples/helix-basic-nextjs/docker-compose.override.yml
+++ b/examples/helix-basic-nextjs/docker-compose.override.yml
@@ -61,6 +61,7 @@ services:
       - ./docker/traefik:C:/etc/traefik
     depends_on:
       - rendering
+    # scale: 0
   
   redis:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-redis:${VERSION:-latest}

--- a/examples/helix-basic-nextjs/docker-compose.yml
+++ b/examples/helix-basic-nextjs/docker-compose.yml
@@ -37,8 +37,6 @@ services:
       SA_PASSWORD: ${SQL_SA_PASSWORD}
       SITECORE_ADMIN_PASSWORD: ${SITECORE_ADMIN_PASSWORD}
       ACCEPT_EULA: "Y"
-    ports:
-      - "14330:1433"
     volumes:
       - type: bind
         source: .\mssql-data
@@ -46,8 +44,6 @@ services:
   solr:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}nonproduction/solr:8.4.0-${SITECORE_VERSION}
-    ports:
-      - "8984:8983"
     volumes:
       - type: bind
         source: .\solr-data

--- a/examples/helix-basic-nextjs/docker-compose.yml
+++ b/examples/helix-basic-nextjs/docker-compose.yml
@@ -79,9 +79,9 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.id-secure.entrypoints=websecure"
-      - "traefik.http.routers.id-secure.rule=Host(`${ID_HOST}`)"
-      - "traefik.http.routers.id-secure.tls=true"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${ID_HOST}`)"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cd:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cd:${SITECORE_VERSION}
@@ -107,9 +107,9 @@ services:
       timeout: 300s
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cd-secure.entrypoints=websecure"
-      - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
-      - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cm:${SITECORE_VERSION}
@@ -146,7 +146,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.middlewares.force-STS-Header.headers.forceSTSHeader=true"
       - "traefik.http.middlewares.force-STS-Header.headers.stsSeconds=31536000"
-      - "traefik.http.routers.cm-secure.entrypoints=websecure"
-      - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
-      - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CM_HOST}`)"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.tls=true"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.middlewares=force-STS-Header"

--- a/examples/helix-basic-nextjs/up.ps1
+++ b/examples/helix-basic-nextjs/up.ps1
@@ -24,7 +24,12 @@ $startTime = Get-Date
 do {
     Start-Sleep -Milliseconds 100
     try {
-        $status = Invoke-RestMethod "http://localhost:8079/api/http/routers/cm-secure@docker"
+
+        #WORKAROUND: https://github.com/Sitecore/docker-tools/issues/38
+        $envFileAbsolutePath = $(Get-Item -Path ".env").FullName
+
+        $compose_project_name = Get-EnvFileVariable -Variable "COMPOSE_PROJECT_NAME" -Path $envFileAbsolutePath        
+        $status = Invoke-RestMethod "http://localhost:8079/api/http/routers/cm-$compose_project_name-secure@docker"
     } catch {
         if ($_.Exception.Response.StatusCode.value__ -ne "404") {
             throw

--- a/examples/helix-basic-tds-consolidated/docker-compose.override.yml
+++ b/examples/helix-basic-tds-consolidated/docker-compose.override.yml
@@ -16,6 +16,7 @@ services:
   traefik:
     volumes:
       - ./docker/traefik:C:/etc/traefik
+    # scale: 0
   
   redis:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-redis:${VERSION:-latest}

--- a/examples/helix-basic-tds-consolidated/docker-compose.override.yml
+++ b/examples/helix-basic-tds-consolidated/docker-compose.override.yml
@@ -80,7 +80,7 @@ services:
       SITECORE_DEVELOPMENT_PATCHES: DevEnvOn,CustomErrorsOff,DebugOn,DiagnosticsOff,InitMessagesOff   
     entrypoint: powershell -Command "& C:\tools\entrypoints\iis\Development.ps1"
     labels:
-      - "traefik.http.routers.cd-secure.rule=Host(`${SITE_HOST}`) || Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${SITE_HOST}`) || Host(`${CD_HOST}`)"
 
   cm:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xm1-cm:${VERSION:-latest}

--- a/examples/helix-basic-tds-consolidated/docker-compose.yml
+++ b/examples/helix-basic-tds-consolidated/docker-compose.yml
@@ -37,16 +37,12 @@ services:
       SA_PASSWORD: ${SQL_SA_PASSWORD}
       SITECORE_ADMIN_PASSWORD: ${SITECORE_ADMIN_PASSWORD}
       ACCEPT_EULA: "Y"
-    ports:
-      - "14330:1433"
     volumes:
       - type: bind
         source: .\mssql-data
         target: c:\data
   solr:
     isolation: ${ISOLATION}
-    ports:
-      - "8984:8983"
     image: ${SITECORE_DOCKER_REGISTRY}nonproduction/solr:8.4.0-${SITECORE_VERSION}
     volumes:
       - type: bind

--- a/examples/helix-basic-tds-consolidated/docker-compose.yml
+++ b/examples/helix-basic-tds-consolidated/docker-compose.yml
@@ -79,9 +79,9 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.id-secure.entrypoints=websecure"
-      - "traefik.http.routers.id-secure.rule=Host(`${ID_HOST}`)"
-      - "traefik.http.routers.id-secure.tls=true"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${ID_HOST}`)"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cd:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cd:${SITECORE_VERSION}
@@ -107,9 +107,9 @@ services:
       timeout: 300s
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cd-secure.entrypoints=websecure"
-      - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
-      - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cm:${SITECORE_VERSION}
@@ -146,7 +146,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.middlewares.force-STS-Header.headers.forceSTSHeader=true"
       - "traefik.http.middlewares.force-STS-Header.headers.stsSeconds=31536000"
-      - "traefik.http.routers.cm-secure.entrypoints=websecure"
-      - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
-      - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CM_HOST}`)"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.tls=true"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.middlewares=force-STS-Header"

--- a/examples/helix-basic-tds/docker-compose.override.yml
+++ b/examples/helix-basic-tds/docker-compose.override.yml
@@ -16,6 +16,7 @@ services:
   traefik:
     volumes:
       - ./docker/traefik:C:/etc/traefik
+    # scale: 0
   
   redis:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-redis:${VERSION:-latest}

--- a/examples/helix-basic-tds/docker-compose.override.yml
+++ b/examples/helix-basic-tds/docker-compose.override.yml
@@ -79,7 +79,7 @@ services:
       SITECORE_DEVELOPMENT_PATCHES: DevEnvOn,CustomErrorsOff,DebugOn,DiagnosticsOff,InitMessagesOff     
     entrypoint: powershell -Command "& C:\tools\entrypoints\iis\Development.ps1"
     labels:
-      - "traefik.http.routers.cd-secure.rule=Host(`${SITE_HOST}`) || Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${SITE_HOST}`) || Host(`${CD_HOST}`)"
 
   cm:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xm1-cm:${VERSION:-latest}

--- a/examples/helix-basic-tds/docker-compose.yml
+++ b/examples/helix-basic-tds/docker-compose.yml
@@ -37,16 +37,12 @@ services:
       SA_PASSWORD: ${SQL_SA_PASSWORD}
       SITECORE_ADMIN_PASSWORD: ${SITECORE_ADMIN_PASSWORD}
       ACCEPT_EULA: "Y"
-    ports:
-      - "14330:1433"
     volumes:
       - type: bind
         source: .\mssql-data
         target: c:\data
   solr:
     isolation: ${ISOLATION}
-    ports:
-      - "8984:8983"
     image: ${SITECORE_DOCKER_REGISTRY}nonproduction/solr:8.4.0-${SITECORE_VERSION}
     volumes:
       - type: bind

--- a/examples/helix-basic-tds/docker-compose.yml
+++ b/examples/helix-basic-tds/docker-compose.yml
@@ -79,9 +79,9 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.id-secure.entrypoints=websecure"
-      - "traefik.http.routers.id-secure.rule=Host(`${ID_HOST}`)"
-      - "traefik.http.routers.id-secure.tls=true"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${ID_HOST}`)"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cd:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cd:${SITECORE_VERSION}
@@ -107,9 +107,9 @@ services:
       timeout: 300s
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cd-secure.entrypoints=websecure"
-      - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
-      - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cm:${SITECORE_VERSION}
@@ -146,7 +146,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.middlewares.force-STS-Header.headers.forceSTSHeader=true"
       - "traefik.http.middlewares.force-STS-Header.headers.stsSeconds=31536000"
-      - "traefik.http.routers.cm-secure.entrypoints=websecure"
-      - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
-      - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CM_HOST}`)"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.tls=true"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.middlewares=force-STS-Header"

--- a/examples/helix-basic-unicorn/docker-compose.override.yml
+++ b/examples/helix-basic-unicorn/docker-compose.override.yml
@@ -15,6 +15,7 @@ services:
   traefik:
     volumes:
       - ./docker/traefik:C:/etc/traefik
+    # scale: 0
   
   redis:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-redis:${VERSION:-latest}

--- a/examples/helix-basic-unicorn/docker-compose.override.yml
+++ b/examples/helix-basic-unicorn/docker-compose.override.yml
@@ -76,7 +76,7 @@ services:
       SITECORE_DEVELOPMENT_PATCHES: CustomErrorsOff
     entrypoint: powershell -Command "& C:\tools\entrypoints\iis\Development.ps1"
     labels:
-      - "traefik.http.routers.cd-secure.rule=Host(`${SITE_HOST}`) || Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${SITE_HOST}`) || Host(`${CD_HOST}`)"
 
   cm:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-xm1-cm:${VERSION:-latest}

--- a/examples/helix-basic-unicorn/docker-compose.yml
+++ b/examples/helix-basic-unicorn/docker-compose.yml
@@ -36,17 +36,13 @@ services:
     environment:
       SA_PASSWORD: ${SQL_SA_PASSWORD}
       SITECORE_ADMIN_PASSWORD: ${SITECORE_ADMIN_PASSWORD}
-      ACCEPT_EULA: "Y"
-    ports:
-      - "14330:1433"
+      ACCEPT_EULA: "Y"      
     volumes:
       - type: bind
         source: .\mssql-data
         target: c:\data
   solr:
     isolation: ${ISOLATION}
-    ports:
-      - "8984:8983"
     image: ${SITECORE_DOCKER_REGISTRY}nonproduction/solr:8.4.0-${SITECORE_VERSION}
     volumes:
       - type: bind

--- a/examples/helix-basic-unicorn/docker-compose.yml
+++ b/examples/helix-basic-unicorn/docker-compose.yml
@@ -79,9 +79,9 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.id-secure.entrypoints=websecure"
-      - "traefik.http.routers.id-secure.rule=Host(`${ID_HOST}`)"
-      - "traefik.http.routers.id-secure.tls=true"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${ID_HOST}`)"
+      - "traefik.http.routers.id-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cd:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cd:${SITECORE_VERSION}
@@ -107,9 +107,9 @@ services:
       timeout: 300s
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cd-secure.entrypoints=websecure"
-      - "traefik.http.routers.cd-secure.rule=Host(`${CD_HOST}`)"
-      - "traefik.http.routers.cd-secure.tls=true"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CD_HOST}`)"
+      - "traefik.http.routers.cd-${COMPOSE_PROJECT_NAME}-secure.tls=true"
   cm:
     isolation: ${ISOLATION}
     image: ${SITECORE_DOCKER_REGISTRY}sitecore-xm1-cm:${SITECORE_VERSION}
@@ -146,7 +146,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.middlewares.force-STS-Header.headers.forceSTSHeader=true"
       - "traefik.http.middlewares.force-STS-Header.headers.stsSeconds=31536000"
-      - "traefik.http.routers.cm-secure.entrypoints=websecure"
-      - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
-      - "traefik.http.routers.cm-secure.tls=true"
-      - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CM_HOST}`)"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.tls=true"
+      - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.middlewares=force-STS-Header"

--- a/examples/traefik/.env
+++ b/examples/traefik/.env
@@ -1,0 +1,4 @@
+COMPOSE_PROJECT_NAME=Traefik
+TRAEFIK_IMAGE=traefik:v2.2.0-windowsservercore-1809
+TRAEFIK_ISOLATION=hyperv
+

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -1,0 +1,121 @@
+# Running Multiple Sitecore Docker-Compose Environments with Traefik
+
+If you need to run multiple Sitecore docker-compose based environments at the same time you need to disable Traefik container on each of them and run a stand-alone Traefik docker-compose based instance.
+
+**DISCALIMER:** **This approach has been tested on Windows 10 with Docker Desktop version 4.10.0 (82025). You might run into issues with older Docker versions!**
+
+## Sitecore docker-compose configuration prerequisites
+
+Your Sitecore docker-compose instances should not have clashes on things that must be unique, for example, **port mappings** and **Traefik route names**.
+
+### Port mappings
+
+Containers port mappings should be the same - you can remove the port mappings or change the port numbers.
+
+Typically, you just need to remove MSSQL and Solr containers port mappings.
+
+***Note: These changes have been already applied to this "Helix.Examples" code base.***
+
+### Traefik router names
+
+Each container must have a unique router name.
+
+Traefik routers are configured in `labels:` sections of each container configuration, in docker-compose file. For example:
+
+    - "traefik.http.routers.cm-secure.entrypoints=websecure"
+    - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
+    - "traefik.http.routers.cm-secure.tls=true"
+    - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+
+ where `cm-secure` is a router name. You can simply make it be unique by injecting the environment variable to its name: `cm-${COMPOSE_PROJECT_NAME}-secure`
+
+    - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.entrypoints=websecure"
+    - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.rule=Host(`${CM_HOST}`)"
+    - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.tls=true"
+    - "traefik.http.routers.cm-${COMPOSE_PROJECT_NAME}-secure.middlewares=force-STS-Header"
+
+***Note: These changes have been already applied to this "Helix.Examples" code base.***
+
+## Configure Traefik
+
+You need to disable Traefik containers on your Sitecore docker-compose files and run Traefik from its own stand-alone docker-compose.
+
+### Disabling Sitecore docker-compose Traefik containers
+
+For each Sitecore environment open `docker-compose.override.yml`, find or add `traefik` container configuration and set `scale: 0`
+
+    traefik:
+        scale: 0
+
+These are "Helix.Examples" `docker-compose.override.yml` files that **you should** consider updating accordingly:
+
+- **[helix-basic-aspnetcore\docker-compose.override.yml](..\helix-basic-aspnetcore\docker-compose.override.yml)**
+- **[helix-basic-nextjs\docker-compose.override.yml](..\helix-basic-nextjs\docker-compose.override.yml)**
+- **[helix-basic-tds\docker-compose.override.yml](..\helix-basic-tds\docker-compose.override.yml)**
+- **[helix-basic-tds-consolidated\docker-compose.override.yml](..\helix-basic-tds-consolidated\docker-compose.override.yml)**
+- **[helix-basic-unicorn\docker-compose.override.yml](..\helix-basic-unicorn\docker-compose.override.yml)**
+
+### Configuring Traefik stand-alone docker-compose
+
+The following example in this `README.md` demonstrates how to run these three "Helix.Examples" environments simultaneously:
+
+- **helix-basic-aspnetcore**
+- **helix-basic-nextjs**
+- **helix-basic-unicorn**
+
+You can use it to understand the approach and then adjust it to your needs.
+
+#### Reference SSL Certificates
+
+Mount to the certificate contained directories to Traefik container in **[docker-compose.override.yml](.\docker-compose.override.yml)** **(The file already contains the changes from the code example below)**
+
+    traefik:
+      volumes:
+        - ../helix-basic-aspnetcore/docker/traefik/certs:C:/etc/traefik/certs/helix-basic-aspnetcore
+        - ../helix-basic-nextjs/docker/traefik/certs:C:/etc/traefik/certs/helix-basic-nextjs
+        - ../helix-basic-unicorn/docker/traefik/certs:C:/etc/traefik/certs/helix-basic-unicorn
+
+**ATTENTION !!!** Each certificate source directory is mounted into its own sub-directory, e.g.: "C:/etc/traefik/certs/**helix-basic-aspnetcore**"
+
+Reference the mounted directory contained certificate files from **[certs_config.yaml](.\config\dynamic\certs_config.yaml)** **(The file already contains the changes from the code example below)**
+
+    tls:
+      certificates:
+        - certFile: C:\etc\traefik\certs\helix-basic-aspnetcore\_wildcard.basic-company-aspnetcore.localhost.pem
+        keyFile: C:\etc\traefik\certs\helix-basic-aspnetcore\_wildcard.basic-company-aspnetcore.localhost-key.pem
+        - certFile: C:\etc\traefik\certs\helix-basic-nextjs\_wildcard.basic-company-nextjs.localhost.pem
+        keyFile: C:\etc\traefik\certs\helix-basic-nextjs\_wildcard.basic-company-nextjs.localhost-key.pem
+        - certFile: C:\etc\traefik\certs\helix-basic-unicorn\_wildcard.basic-company-unicorn.localhost.pem
+        keyFile: C:\etc\traefik\certs\helix-basic-unicorn\_wildcard.basic-company-unicorn.localhost-key.pem   
+
+#### Register Traefik on Sitecore docker-compose networks
+
+Each Sitecore docker-compose creates a default network automatically which is named: `<docker-compose-project-name>_default`.
+
+`<docker-compose-project-name>` is defined by `.env` file contained environment variable `COMPOSE_PROJECT_NAME`, otherwise by the parent directory name of the `docker-compose.yml` file.
+
+This how you know upfront the network names and add them to the `traefik` container configuration in **[docker-compose.override.yml](.\docker-compose.override.yml)** **(The file already contains the changes from the code example below)**
+
+    traefik:
+      networks:
+        - basic-company-aspnetcore_default
+        - basic-company-nextjs_default
+        - basic-company-unicorn_default
+
+Then, you also need to register these **external** networks in the Traefik's **[docker-compose.override.yml](.\docker-compose.override.yml)** **(The file already contains the changes from the code example below)**
+
+    networks:
+      basic-company-aspnetcore_default:
+        name: basic-company-aspnetcore_default
+        external: true
+      basic-company-nextjs_default:
+        name: basic-company-nextjs_default
+        external: true
+       basic-company-unicorn_default:
+         name: basic-company-unicorn_default
+         external: true
+
+## Starting Sitecore Environments
+
+- Start each Sitecore environment as usual, for example, running its own : `./up.ps1` or `docker-compose up -d`.
+- Start Traefik by running [./up.ps1](./up.ps1)

--- a/examples/traefik/docker-compose.override.yml
+++ b/examples/traefik/docker-compose.override.yml
@@ -1,0 +1,24 @@
+version: "2.4"
+
+services:
+
+  traefik:
+    volumes:
+      - ../helix-basic-aspnetcore/docker/traefik/certs:C:/etc/traefik/certs/helix-basic-aspnetcore
+      - ../helix-basic-nextjs/docker/traefik/certs:C:/etc/traefik/certs/helix-basic-nextjs
+      - ../helix-basic-unicorn/docker/traefik/certs:C:/etc/traefik/certs/helix-basic-unicorn
+    networks:
+      - basic-company-aspnetcore_default
+      - basic-company-nextjs_default
+      - basic-company-unicorn_default
+
+networks:
+  basic-company-aspnetcore_default:
+    name: basic-company-aspnetcore_default
+    external: true
+  basic-company-nextjs_default:
+    name: basic-company-nextjs_default
+    external: true
+  basic-company-unicorn_default:
+    name: basic-company-unicorn_default
+    external: true

--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "2.4"
+services:
+  traefik:
+    isolation: ${TRAEFIK_ISOLATION}
+    image: ${TRAEFIK_IMAGE}
+    command:
+      - "--ping"
+      - "--api.insecure=true"
+      - "--providers.docker.endpoint=npipe:////./pipe/docker_engine"
+      - "--providers.docker.exposedByDefault=false"
+      - "--providers.file.directory=C:/etc/traefik/config/dynamic"
+      - "--entryPoints.websecure.address=:443"
+    ports:
+      - "443:443"
+      - "8079:8080"
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+    volumes:
+      - source: \\.\pipe\docker_engine
+        target: \\.\pipe\docker_engine
+        type: npipe
+      - ./docker/traefik/config:C:/etc/traefik/config

--- a/examples/traefik/docker/traefik/README.md
+++ b/examples/traefik/docker/traefik/README.md
@@ -1,0 +1,5 @@
+# Traefik Proxy
+
+This path contains certificates and configuration for the Traefik
+reverse proxy, which is used in container-based Sitecore development
+environments. See Sitecore Containers documentation for more information.

--- a/examples/traefik/docker/traefik/config/dynamic/certs_config.yaml
+++ b/examples/traefik/docker/traefik/config/dynamic/certs_config.yaml
@@ -1,0 +1,8 @@
+tls:
+  certificates:
+    - certFile: C:\etc\traefik\certs\helix-basic-aspnetcore\_wildcard.basic-company-aspnetcore.localhost.pem
+      keyFile: C:\etc\traefik\certs\helix-basic-aspnetcore\_wildcard.basic-company-aspnetcore.localhost-key.pem
+    - certFile: C:\etc\traefik\certs\helix-basic-nextjs\_wildcard.basic-company-nextjs.localhost.pem
+      keyFile: C:\etc\traefik\certs\helix-basic-nextjs\_wildcard.basic-company-nextjs.localhost-key.pem
+    - certFile: C:\etc\traefik\certs\helix-basic-unicorn\_wildcard.basic-company-unicorn.localhost.pem
+      keyFile: C:\etc\traefik\certs\helix-basic-unicorn\_wildcard.basic-company-unicorn.localhost-key.pem      

--- a/examples/traefik/up.ps1
+++ b/examples/traefik/up.ps1
@@ -1,0 +1,3 @@
+# Start the Traefik instance
+Write-Host "Starting Traefik ..." -ForegroundColor Green
+docker-compose up -d


### PR DESCRIPTION
Enhances #156

Added "Running Multiple Sitecore Docker-Compose Environments with Traefik" example

See the implementation details and guidelines in the https://github.com/Sitecore/Helix.Examples/blob/b0dd852e01df60ce12068d6bc40adbc42d12ab40/examples/traefik/README.md
